### PR TITLE
FIX LEN OVERFLOW | UPDATE HASH SWAP | UPDATE TAG HASH

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ main.exe
 Cerberus
 Cerberus.exe
 test.exe
-test
+test*
 
 # VSCode
 .vscode 

--- a/src/lib/cerberus.h
+++ b/src/lib/cerberus.h
@@ -7,9 +7,9 @@
 #define _CERBERUS_H
 
 /* Encript a keyword with single-tag */
-int encript (const char *keyword, const char *keysimple);
+int hash (const char *password, const char *tag);
 /* Encript a keyword without single-tag */
-int l_encript (const char *keyword);
+int legacyHasher (const char *password);
 /* Swap a hash */
-void swap(unsigned char *sha256_hash, const unsigned char *md5_hash, const char *keysimple);
+void swap (unsigned char *sha256Key, const unsigned char *sha256Tag, const char *tag);
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -15,8 +15,8 @@ int main(int argc, char *argv[]) {
     return -1;
   }
   if (!(strcmp(argv[2], "-o")))
-    l_encript(argv[1]);
+    legacyHasher(argv[1]);
   else
-    encript(argv[1], argv[2]);
+    hash(argv[1], argv[2]);
   return 0;
 }


### PR DESCRIPTION
Prevented tag size from overwriting the hash too much, swapped MD5 for SHA256, and fixed some extra logic issues.
#8 